### PR TITLE
Feature/create todo

### DIFF
--- a/app/Http/Controllers/TaskController.php
+++ b/app/Http/Controllers/TaskController.php
@@ -9,6 +9,7 @@ use JWTAuth;
 
 class TaskController extends Controller
 {
+    function __construct()
     {
         //set [Customers] as the model that will be used for this class
         \Config::set('auth.providers.users.model', \App\Models\Customers::class);

--- a/app/Http/Controllers/TaskController.php
+++ b/app/Http/Controllers/TaskController.php
@@ -9,7 +9,10 @@ use JWTAuth;
 
 class TaskController extends Controller
 {
-    
+    {
+        //set [Customers] as the model that will be used for this class
+        \Config::set('auth.providers.users.model', \App\Models\Customers::class);
+    }
     public function create(Request $request)
     {
         // validating POST parameter, title required 


### PR DESCRIPTION
Updated model used for authentication. Previously the 'user' model refers to the customer, but after some change, the 'user' used in the authentication process referred to the admin. So to use customer token as as the beared token in the customer verification process will return a null when trying to get the customer_id by `JWTAuth::user()->id`.

File(s) modified:
- api/Http/Controllers/**TaskController.php**