### PR TITLE
Feature Added: Delete To-Do

### DIFF
--- a/app/Http/Controllers/TaskController.php
+++ b/app/Http/Controllers/TaskController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers;
 use App\Models\Tasks;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Validator;
+use Carbon\Carbon;
 use JWTAuth;
 
 class TaskController extends Controller
@@ -42,5 +43,39 @@ class TaskController extends Controller
         $status = "success";
         $message = "Data berhasil disimpan";
         return response()->json(compact('status', 'message'), 201);
+    }
+    public function delete($id_todolist, Request $request)
+    {
+        $currentUser = JWTAuth::user()->id;
+        if (Tasks::where('id', $id_todolist)->exists()) {
+            $task = Tasks::find($id_todolist);
+            if ($task->is_deleted == 1){
+                $status = "failed";
+                $message = "Task sudah dihapus";
+                return response()->json(compact('status', 'message'), 404);
+            }
+            if($task->customer_id == $currentUser){
+                $sekarang = Carbon::now();
+                $task->deleted_at = $sekarang;
+                $task->is_deleted = 1;
+                $task->save();
+                
+                // Success Response
+                $status = "success";
+                $message = "Data berhasil dihapus";
+                return response()->json(compact('status', 'message'),201);
+                
+                // Customer does not own the task
+                } else{
+                    $status = "failed";
+                    $message = "Anda tidak memiliki task tersebut";
+                    return response()->json(compact('status', 'message'), 403);
+                }
+            // Task with that that id  does not exist
+          } else {
+              $status = "failed";
+              $message = "Data tidak ditemukan";
+              return response()->json(compact('status', 'message'), 404);
+          }
     }
 }

--- a/app/Http/Controllers/TaskController.php
+++ b/app/Http/Controllers/TaskController.php
@@ -61,4 +61,38 @@ class TaskController extends Controller
         $message = "Data berhasil didapatkan";
         return response()->json(compact('status', 'message','data'), 200);
     }
+    public function delete($id_todolist, Request $request)
+    {
+        $currentUser = JWTAuth::user()->id;
+        if (Tasks::where('id', $id_todolist)->exists()) {
+            $task = Tasks::find($id_todolist);
+            if ($task->is_deleted == 1){
+                $status = "failed";
+                $message = "Task sudah dihapus";
+                return response()->json(compact('status', 'message'), 404);
+            }
+            if($task->customer_id == $currentUser){
+                $sekarang = Carbon::now();
+                $task->deleted_at = $sekarang;
+                $task->is_deleted = 1;
+                $task->save();
+                
+                // Success Response
+                $status = "success";
+                $message = "Data berhasil dihapus";
+                return response()->json(compact('status', 'message'),201);
+                
+                // Customer does not own the task
+                } else{
+                    $status = "failed";
+                    $message = "Anda tidak memiliki task tersebut";
+                    return response()->json(compact('status', 'message'), 403);
+                }
+            // Task with that that id  does not exist
+          } else {
+              $status = "failed";
+              $message = "Data tidak ditemukan";
+              return response()->json(compact('status', 'message'), 404);
+          }
+    }
 }

--- a/app/Http/Controllers/TaskController.php
+++ b/app/Http/Controllers/TaskController.php
@@ -46,7 +46,6 @@ class TaskController extends Controller
     }
     public function view()
     {
-        // geting the user id from token
         $currentUser = JWTAuth::user()->id;
         // Validating whether $currentUser is null
         if (is_null($currentUser)){
@@ -64,6 +63,12 @@ class TaskController extends Controller
     public function delete($id_todolist, Request $request)
     {
         $currentUser = JWTAuth::user()->id;
+        // Validating whether $currentUser is null
+        if (is_null($currentUser)){
+            $status = "failed";
+            $message = "Customer tidak ditemukan";
+            return response()->json(compact('status', 'message'), 404);
+        }
         if (Tasks::where('id', $id_todolist)->exists()) {
             $task = Tasks::find($id_todolist);
             if ($task->is_deleted == 1){

--- a/routes/api.php
+++ b/routes/api.php
@@ -35,5 +35,6 @@ Route::post('v1/admin/login', [UserController::class, 'authenticate']);
 Route::group(['middleware' => ['jwt.verify']], function() {
     Route::post('/v1/todo/add', [TaskController::class, 'create']);
     Route::get('v1/admin/users', [CustomerController::class, 'getListOfCustomers']);
+    Route::get('/v1/todo/list', [TaskController::class, 'view']);
     Route::post('/v1/todo/delete/{id_todolist}', [TaskController::class, 'delete']);
 });

--- a/routes/api.php
+++ b/routes/api.php
@@ -30,4 +30,5 @@ Route::post('v1/admin/login', [UserController::class, 'authenticate']);
 Route::group(['middleware' => ['jwt.verify']], function() {
     Route::post('/v1/todo/add', [TaskController::class, 'create']);
     Route::get('v1/admin/users', [CustomerController::class, 'getListOfCustomers']);
+    Route::post('/v1/todo/delete/{id_todolist}', [TaskController::class, 'delete']);
 });


### PR DESCRIPTION
I've added an endpoint for customers to delete a to-do task. This feature is a soft delete, only update the is_deleted and deleted_at value

File(s) modified:

- app/Http/Controllers/**TaskController.php**
- routes/**api.php**

Feature added:

- Delete To-do: Customers can delete a to-do task, by doing a POST request via endpoint `/api/v1/todo/delete/{id_todolist}` This feature will update the `is_deleted` and `deleted_at` attributes in `tasks`. The Customer can only delete their data and the data has not to be deleted. Corresponding function/method that handles this feature: `TaskController::delete($id_todolist, Request $request)`